### PR TITLE
fix the allowed modes on the Augustus bridge

### DIFF
--- a/src/main/java/org/matsim/prepare/PrepareNetwork.java
+++ b/src/main/java/org/matsim/prepare/PrepareNetwork.java
@@ -3,6 +3,7 @@ package org.matsim.prepare;
 import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
@@ -12,6 +13,9 @@ import org.matsim.contrib.emissions.OsmHbefaMapping;
 import org.matsim.core.network.NetworkUtils;
 import picocli.CommandLine;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.matsim.utils.DresdenUtils.getFreightModes;
@@ -39,6 +43,7 @@ public class PrepareNetwork implements MATSimAppCommand {
 
 		Network network = NetworkUtils.readNetwork(networkFile);
 
+		fixAugustusBridgeAllowedModes(network);
 		prepareFreightNetwork(network);
 		prepareEmissionsAttributes(network);
 
@@ -76,5 +81,32 @@ public class PrepareNetwork implements MATSimAppCommand {
 //		do not use VspHbefaRoadTypeMapping() as it results in almost every road to mapped to "highway"!
 		HbefaRoadTypeMapping roadTypeMapping = OsmHbefaMapping.build();
 		roadTypeMapping.addHbefaMappings(network);
+	}
+
+	/**
+	 * do not allow car and truck on the Augustus bridge
+	 */
+	public static void fixAugustusBridgeAllowedModes(Network network){
+		// The links to be closed down for car and truck (bike is still allowed)
+		List<Link> linksToFix = new ArrayList<>();
+		linksToFix.add(network.getLinks().get(Id.createLinkId("237502199")));
+		linksToFix.add(network.getLinks().get(Id.createLinkId("12497357")));
+		linksToFix.add(network.getLinks().get(Id.createLinkId("1031454500")));
+		linksToFix.add(network.getLinks().get(Id.createLinkId("4265202")));
+		linksToFix.add(network.getLinks().get(Id.createLinkId("60611109#0")));
+		linksToFix.add(network.getLinks().get(Id.createLinkId("-99478092")));
+		linksToFix.add(network.getLinks().get(Id.createLinkId("-1329159900")));
+		linksToFix.add(network.getLinks().get(Id.createLinkId("-264360404")));
+		linksToFix.add(network.getLinks().get(Id.createLinkId("-12497357")));
+		linksToFix.add(network.getLinks().get(Id.createLinkId("-376145739")));
+
+		for (Link link : linksToFix) {
+			Set<String> originalAllowedModes = link.getAllowedModes();
+			Set<String> updatedAllowedModes = new HashSet<>(originalAllowedModes);
+			updatedAllowedModes.remove(TransportMode.car);
+			updatedAllowedModes.remove(TransportMode.truck);
+			updatedAllowedModes.remove(TransportMode.ride);
+			link.setAllowedModes(updatedAllowedModes);
+		}
 	}
 }

--- a/src/main/java/org/matsim/run/scenarios/DresdenModel.java
+++ b/src/main/java/org/matsim/run/scenarios/DresdenModel.java
@@ -231,6 +231,11 @@ public class DresdenModel extends MATSimApplication {
 
 	@Override
 	protected void prepareScenario(Scenario scenario) {
+		// 		fix the allowed modes for Augustus bridge.
+		// The Augustus bridge is only for walk, bike, PT in the reality.
+		// In the MATSim network, however, cars and trucks are allowed.
+		// It is right next to the Carola bridge, we should set it properly to observe the impact of the collapse of the Carola bridge.
+		PrepareNetwork.fixAugustusBridgeAllowedModes(scenario.getNetwork());
 		//		add freight modes of DresdenUtils to network.
 //		this happens in the makefile pipeline already, but we do it here anyways, in case somebody uses a preliminary network.
 		PrepareNetwork.prepareFreightNetwork(scenario.getNetwork());


### PR DESCRIPTION
Currently, only walk, pt, bike (and emergency vehicles) are allowed on the Augustus bridge. In the MATSim network, however, car and trucks are also allowewd (see also #37 in the discussion).

Since the Augustus bridge is right next to the Carola bridge, we should fix the allowed mode when studying the impact of the collapse of the Carola bridge. 

We could either update the network directly (in which case I cannot create a PR), or modify the run script (as shown in this PR). I am not sure which way is better. What do you think? @simei94 @kainagel 

Thank you very much! 