### PR TITLE
remove default 10% config

### DIFF
--- a/src/main/java/org/matsim/run/scenarios/DresdenScenario.java
+++ b/src/main/java/org/matsim/run/scenarios/DresdenScenario.java
@@ -72,8 +72,6 @@ public class DresdenScenario extends MATSimApplication {
 
 	public static final String VERSION = "v1.0";
 
-	@CommandLine.Mixin
-	private final SampleOptions sample = new SampleOptions(100, 25, 10, 1);
 	@CommandLine.Option(names = "--emissions", defaultValue = "ENABLED", description = "Define if emission analysis should be performed or not.")
 	DresdenUtils.FunctionalityHandling emissions;
 	@CommandLine.Option(names = "--explicit-walk-intermodality", defaultValue = "ENABLED", description = "Define if explicit walk intermodality parameter to/from pt should be set or not (use default).")
@@ -107,17 +105,6 @@ public class DresdenScenario extends MATSimApplication {
 		simWrapper.defaultParams().setMapZoomLevel(6.8);
 //		the tarifzone shp file basically is a dresden shp file with fare prices as additional information
 		simWrapper.defaultParams().setShp(String.format("vvo_tarifzone_10_dresden/%s_vvo_tarifzone_10_dresden_utm32n.shp", VERSION));
-
-		if (sample.isSet()){
-			config.controller().setOutputDirectory(sample.adjustName(config.controller().getOutputDirectory()));
-			config.plans().setInputFile(sample.adjustName(config.plans().getInputFile()));
-			config.controller().setRunId(sample.adjustName(config.controller().getRunId()));
-
-			config.qsim().setFlowCapFactor(sample.getSample());
-			config.qsim().setStorageCapFactor(sample.getSample());
-			config.counts().setCountsScaleFactor(sample.getSample());
-			simWrapper.setSampleSize(sample.getSample());
-		}
 
 		config.vspExperimental().setVspDefaultsCheckingLevel(VspExperimentalConfigGroup.VspDefaultsCheckingLevel.abort);
 

--- a/src/main/java/org/matsim/run/scenarios/DresdenScenario.java
+++ b/src/main/java/org/matsim/run/scenarios/DresdenScenario.java
@@ -85,7 +85,7 @@ public class DresdenScenario extends MATSimApplication {
 	}
 
 	public DresdenScenario() {
-		super(String.format("input/%s/dresden-%s-10pct.config.xml", VERSION, VERSION));
+		super();
 	}
 
 	public static void main(String[] args) {


### PR DESCRIPTION
If this is ok for you, I would remove the default config for version 1.0.2. In later matsim versions it wont be possible to pass a default config at all. It is much easier for teaching if students are forced to pass a config (1%). 

I also removed the sample options.